### PR TITLE
Update lavalink urls

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -65,7 +65,7 @@ function startLavalink() {
 
 
 console.log("Fetching latest Lavalink.jar url...")
-fetch("https://api.github.com/repos/freyacodes/Lavalink/releases/latest")
+fetch("https://api.github.com/repos/Cog-Creators/Lavalink-Jars/releases/latest")
     .then(res => res.json())
     .then(json => {
         if(json.assets[0] && json.assets[0].browser_download_url){
@@ -80,7 +80,7 @@ fetch("https://api.github.com/repos/freyacodes/Lavalink/releases/latest")
             priorVersion[0] = priorVersion[0].replace("v","")
             priorVersion = priorVersion.join(".")
 
-            let priorDL_URL = `https://github.com/freyacodes/Lavalink/releases/download/${priorVersion}/Lavalink.jar`
+            let priorDL_URL = `https://github.com/Cog-Creators/Lavalink-Jars/releases/download/${priorVersion}/Lavalink.jar`
             console.log("Found: "+priorDL_URL)
             download(priorDL_URL, "./Lavalink.jar", startLavalink)
         }


### PR DESCRIPTION
The current jar urls have some issues on using `youtube search`, it always returns `No Matches Found`. Now on this issue, the [issue](https://github.com/freyacodes/Lavalink/issues/660) is confirmed to be a bug. The issue is fixed on the dev version but the script can't get it right now, so i did another option. Just use another lavalink jar, i used the lavalink jar by [Cog-Creators/Lavalink-Jars](https://github.com/Cog-Creators/Lavalink-Jars) and their latest version seems to be working well in my experience.